### PR TITLE
Converted functions from api.ts to apiContext

### DIFF
--- a/web/src/context/apiContext.tsx
+++ b/web/src/context/apiContext.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { createContext, useContext, useState, useEffect, ReactNode, useCallback } from 'react';
+import { createContext, useState, useEffect, ReactNode, useCallback } from 'react';
 import ReconnectingWebSocket from 'reconnecting-websocket';
 import { api } from '../scripts/api';
 import { createUseContextHook } from './hookCreator';
@@ -7,6 +7,19 @@ import { createChannel, createClient, Metadata } from 'nice-grpc-web';
 import { ComfyClient, ComfyDefinition, ComfyMessage, JobCreated } from '../../autogen_web_ts/comfy_request.v1.ts';
 import { WorkflowStep } from '../../autogen_web_ts/comfy_request.v1.ts';
 import { SerializedGraph } from '../types/litegraph';
+import {
+    IComfyApi,
+    ComfyItemURLType,
+    EmbeddingsResponse,
+    HistoryResponse,
+    UserConfigResponse,
+    SystemStatsResponse,
+    SettingsResponse,
+    storeUserDataOptions,
+    ComfyHistoryItems,
+} from '../types/api.ts';
+import API_URL from './apiURL.ts';
+import { ComfyObjectInfo } from '../types/comfy';
 
 // This is injected into index.html by `start.py`
 declare global {
@@ -19,7 +32,7 @@ declare global {
 
 type ProtocolType = 'grpc' | 'ws';
 
-interface IApiContext {
+interface IApiContext extends Partial<IComfyApi> {
     sessionId?: string;
     connectionStatus: string;
     comfyClient: ComfyClient | null;
@@ -215,6 +228,215 @@ export const ApiContextProvider: React.FC<{ children: ReactNode }> = ({ children
         [requestMetadata, serverUrl, serverProtocol, comfyClient, sessionId]
     );
 
+    // putting these functions here for now cos we might want to find a way to go with the gRPC and the fetch requests
+    const generateURL = (route: string): string => {
+        return serverUrl + route;
+    };
+
+    const fetchApi = (route: string, options?: RequestInit) => {
+        if (!options) {
+            options = {};
+        }
+        if (!options.headers) {
+            options.headers = {};
+        }
+
+        return fetch(generateURL(route), options);
+    };
+
+    /**
+     * Gets a list of embedding names
+     * @returns An array of script urls to import
+     */
+    const getEmbeddings = async (): Promise<EmbeddingsResponse> => {
+        const resp = await fetchApi(API_URL.GET_EMBEDDINGS, { cache: 'no-store' });
+        return await resp.json();
+    };
+
+    /**
+     * Loads node object definitions for the graph
+     * @returns The node definitions
+     */
+    const getNodeDefs = async (): Promise<Record<string, ComfyObjectInfo>> => {
+        const resp = await fetchApi(API_URL.GET_NODE_DEFS, { cache: 'no-store' });
+        return await resp.json();
+    };
+
+    /**
+     * Gets the prompt execution history
+     * @returns Prompt history including node outputs
+     */
+    const getHistory = async (max_items: number = 200): Promise<ComfyHistoryItems> => {
+        try {
+            const res = await fetchApi(API_URL.GET_HISTORY(max_items));
+            if (!res.ok) {
+                throw new Error(`Error fetching history: ${res.status} ${res.statusText}`);
+            }
+
+            const history = (await res.json()) as HistoryResponse;
+            return { History: Object.values(history) };
+        } catch (error) {
+            console.error(error);
+            return { History: [] };
+        }
+    };
+
+    /**
+     * Gets system & device stats
+     * @returns System stats such as python version, OS, per device info
+     */
+    const getSystemStats = async (): Promise<SystemStatsResponse> => {
+        const res = await fetchApi(API_URL.GET_SYSTEM_STATS);
+        if (!res.ok) {
+            throw new Error(`Error fetching system stats: ${res.status} ${res.statusText}`);
+        }
+
+        return await res.json();
+    };
+
+    /**
+     * Sends a POST request to the API
+     * @param {*} type The endpoint to post to: queue or history
+     * @param {*} body Optional POST data
+     */
+    const postItem = async (type: ComfyItemURLType, body?: object): Promise<void> => {
+        try {
+            await fetchApi('/' + type, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: body ? JSON.stringify(body) : undefined,
+            });
+        } catch (error) {
+            console.error(error);
+        }
+    };
+
+    /**
+     * Deletes an item from the specified list
+     * @param {string} type The type of item to delete, queue or history
+     * @param {number} id The id of the item to delete
+     */
+    const deleteItem = async (type: ComfyItemURLType, id: number) => {
+        await postItem(type, { delete: [id] });
+    };
+
+    /**
+     * Clears the specified list
+     * @param {string} type The type of list to clear, queue or history
+     */
+    const clearItems = async (type: ComfyItemURLType) => {
+        await postItem(type, { clear: true });
+    };
+
+    /**
+     * Interrupts the execution of the running prompt
+     */
+    const interrupt = async (): Promise<void> => {
+        await postItem('interrupt');
+    };
+
+    /**
+     * Gets user configuration data and where data should be stored
+     * @returns { Promise<{ storage: "server" | "browser", users?: Promise<string, unknown>, migrated?: boolean }> }
+     */
+    const getUserConfig = async (): Promise<UserConfigResponse> => {
+        const response = await fetchApi(API_URL.GET_USER_CONFIG);
+        return await response.json();
+    };
+
+    /**
+     * Creates a new user
+     * @param { string } username
+     * @returns The fetch response
+     */
+    const createUser = (username: string) => {
+        return fetchApi(API_URL.CREATE_USER, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ username }),
+        });
+    };
+
+    /**
+     * Gets all setting values for the current user
+     * @returns { Promise<string, unknown> } A dictionary of id -> value
+     */
+    const getSettings = async (): Promise<SettingsResponse> => {
+        const response = await fetchApi(API_URL.GET_SETTINGS);
+        return await response.json();
+    };
+
+    /**
+     * Gets a setting for the current user
+     * @param { string } id The id of the setting to fetch
+     * @returns { Promise<unknown> } The setting value
+     */
+    const getSetting = async (id: string) => {
+        const response = await fetchApi(API_URL.GET_SETTING_BY_ID(id));
+        return await response.json();
+    };
+
+    /**
+     * Stores a dictionary of settings for the current user
+     * @param { Record<string, unknown> } settings Dictionary of setting id -> value to save
+     * @returns { Promise<void> }
+     */
+    const storeSettings = (settings: Record<string, unknown>) => {
+        return fetchApi(API_URL.STORE_SETTINGS, {
+            method: 'POST',
+            body: JSON.stringify(settings),
+        });
+    };
+
+    /**
+     * Stores a setting for the current user
+     * @param { string } id The id of the setting to update
+     * @param { unknown } value The value of the setting
+     * @returns { Promise<void> }
+     */
+    const storeSetting = (id: string, value: Record<string, any>) => {
+        return fetchApi(`/settings/${encodeURIComponent(id)}`, {
+            method: 'POST',
+            body: JSON.stringify(value),
+        });
+    };
+
+    /**
+     * Gets a user data file for the current user
+     * @param { string } file The name of the userData file to load
+     * @param { RequestInit } [options]
+     * @returns { Promise<unknown> } The fetch response object
+     */
+    const getUserData = async (file: string, options: RequestInit) => {
+        return await fetchApi(API_URL.GET_USER_DATA_FILE(file), options);
+    };
+
+    /**
+     * Stores a user data file for the current user
+     * @param { string } file The name of the userData file to save
+     * @param { unknown } data The data to save to the file
+     * @param { RequestInit & { stringify?: boolean, throwOnError?: boolean } } [options]
+     * @returns { Promise<void> }
+     */
+    const storeUserData = async (
+        file: string,
+        data: BodyInit,
+        options: storeUserDataOptions = { stringify: true, throwOnError: true }
+    ) => {
+        const resp = await fetchApi(API_URL.STORE_USER_DATA_FILE(file), {
+            method: 'POST',
+            body: options?.stringify ? JSON.stringify(data) : data,
+            ...options,
+        });
+        if (resp.status !== 200) {
+            throw new Error(`Error storing user data file '${file}': ${resp.status} ${resp.statusText}`);
+        }
+    };
+
     return (
         <ApiContext.Provider
             value={{
@@ -223,6 +445,22 @@ export const ApiContextProvider: React.FC<{ children: ReactNode }> = ({ children
                 comfyClient,
                 requestMetadata,
                 runWorkflow,
+
+                // API functions
+                getEmbeddings,
+                getNodeDefs,
+                getHistory,
+                getSystemStats,
+                deleteItem,
+                clearItems,
+                interrupt,
+                getUserConfig,
+                createUser,
+                getSettings,
+                storeSettings,
+                storeSetting,
+                getUserData,
+                storeUserData,
             }}
         >
             {children}

--- a/web/src/context/apiUrl.ts
+++ b/web/src/context/apiUrl.ts
@@ -1,0 +1,15 @@
+const API_URL = {
+    GET_EMBEDDINGS: '/embeddings',
+    GET_NODE_DEFS: '/object_info',
+    GET_HISTORY: (maxItems: number) => `/history?max_items=${maxItems}`,
+    GET_SYSTEM_STATS: '/system_stats',
+    GET_USER_CONFIG: '/users',
+    CREATE_USER: '/users',
+    GET_SETTINGS: '/settings',
+    GET_SETTING_BY_ID: (id: string) => `/settings/${id}`,
+    STORE_SETTINGS: '/settings',
+    GET_USER_DATA_FILE: (file: string) => `/userdata/${encodeURIComponent(file)}`,
+    STORE_USER_DATA_FILE: (file: string) => `/userdata/${encodeURIComponent(file)}`,
+};
+
+export default API_URL;

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -4,6 +4,10 @@ import { ComfyObjectInfo } from './comfy';
 
 export type EmbeddingsResponse = string[];
 
+export type ComfyItemURLType = 'queue' | 'history' | 'interrupt';
+
+export type storeUserDataOptions = RequestInit & { stringify?: boolean; throwOnError?: boolean };
+
 export interface UploadFileResponse {
     name: string;
     type: string;


### PR DESCRIPTION
After adding this, thinking of using REDUCERS and we can be able to create our useAppDispatch to dispatch requests (from the apiContext). Therefore we can also have a state and initialState of things we want to store and REDUCERS can make changes to this state.

Something like this:

```
const initialState = {
  loading: true,
  isSessionAuthenticated: false,
  userData: {},
  embeddings: []
};
```

`  const [state, dispatch] = useReducer(AuthReducers, initialState);`

 ```
const getEmbeddings = async (): Promise<EmbeddingsResponse> => {
        const resp = await fetchApi(API_URL.GET_EMBEDDINGS, { cache: 'no-store' });
        const embeddings = await resp.json();
        dispatch({
            type: 'SET_EMBEDDINGS',
            payload: embeddings,
        });
        return await resp.json();
    };
```


Therefore when we call the function `getEmbeddings`, it fetches and saves in the state and we can get the current value from the state (exported in the apiContext value).
